### PR TITLE
Await pollData

### DIFF
--- a/Assets/PublicExample/main.js
+++ b/Assets/PublicExample/main.js
@@ -1104,4 +1104,4 @@ async function pollData() {
 
 // 启动轮询
 setInterval(pollData, POLL_INTERVAL);
-pollData();
+await pollData();


### PR DESCRIPTION
The current code in Assets/PublicExample/main.js likely works fine most of the time, but The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced. Close this if it’s not worth it.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.