### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ QQ 交流群：150453391
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Widdit/now-playing-service&type=date&legend=top-left)](https://www.star-history.com/#Widdit/now-playing-service&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Widdit/now-playing-service&type=date&legend=top-left)](https://star-history.dera.page/#Widdit/now-playing-service&type=date&legend=top-left)


### PR DESCRIPTION
当前仓库中的 Star History 图表因 GitHub stargazer API 限制而无法正常展示。此 PR 将图表切换至基于新数据源的 star-history.dera.page，无需 API Token，确保 Star 数据图表能够稳定显示。