### PR TITLE
fix: 修复网易云 3.1.38 下 UIA 进度读取阻塞导致的歌词延迟

### DIFF
--- a/external_programs/AudioService/GetMusicStatus/Helpers/NeteaseHistoryReader.cs
+++ b/external_programs/AudioService/GetMusicStatus/Helpers/NeteaseHistoryReader.cs
@@ -1,0 +1,226 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// 从网易云音乐 3.x 自己维护的播放历史数据库中读取最近一次开播时间。
+///
+/// 这里只在歌曲/开播时间变化时向 Now Playing 提供一次初始进度，之后仍由
+/// Now Playing 原有计时器负责推进与暂停，避免把本地数据库当作高频时间轴。
+/// </summary>
+public static class NeteaseHistoryReader
+{
+    private const int SQLITE_OK = 0;
+    private const int SQLITE_ROW = 100;
+    private const int SQLITE_OPEN_READONLY = 0x00000001;
+    private const int SQLITE_OPEN_NOMUTEX = 0x00008000;
+
+    private static readonly string DatabasePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NetEase", "CloudMusic", "Library", "webdb.dat");
+
+    private static readonly object CacheLock = new object();
+    private static long _lastDatabaseStamp = long.MinValue;
+    private static HistorySnapshot _cachedSnapshot;
+
+    /// <summary>
+    /// 在窗口标题与网易云最近播放记录匹配时，返回基于开播时间估算的初始进度。
+    /// </summary>
+    /// <param name="windowTitle">网易云当前播放窗口标题。</param>
+    /// <param name="currentSeconds">估算的当前播放秒数。</param>
+    /// <param name="totalSeconds">歌曲总时长（秒）。</param>
+    /// <param name="playtimeMilliseconds">网易云记录的开播 Unix 时间戳（毫秒）。</param>
+    /// <returns>记录有效且与当前窗口标题匹配时返回 true。</returns>
+    public static bool TryGetInitialProgress(
+        string windowTitle,
+        out int currentSeconds,
+        out int totalSeconds,
+        out long playtimeMilliseconds)
+    {
+        currentSeconds = -1;
+        totalSeconds = -1;
+        playtimeMilliseconds = -1;
+
+        HistorySnapshot snapshot = ReadLatestCached();
+        if (snapshot == null || string.IsNullOrWhiteSpace(windowTitle))
+        {
+            return false;
+        }
+
+        // 防止数据库尚未切到新曲时，把上一首的进度套到新标题上。
+        if (string.IsNullOrWhiteSpace(snapshot.Title)
+            || windowTitle.IndexOf(snapshot.Title, StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
+
+        long elapsedMilliseconds = DateTimeOffset.Now.ToUnixTimeMilliseconds() - snapshot.PlaytimeMilliseconds;
+        if (elapsedMilliseconds < -1000 || snapshot.DurationMilliseconds <= 0)
+        {
+            return false;
+        }
+
+        // 允许少量时钟/取整误差；明显超出歌曲时长则视为陈旧记录。
+        if (elapsedMilliseconds > snapshot.DurationMilliseconds + 3000)
+        {
+            return false;
+        }
+
+        elapsedMilliseconds = Math.Max(0, Math.Min(elapsedMilliseconds, snapshot.DurationMilliseconds));
+        currentSeconds = (int)(elapsedMilliseconds / 1000);
+        totalSeconds = Math.Max(1, (int)(snapshot.DurationMilliseconds / 1000));
+        playtimeMilliseconds = snapshot.PlaytimeMilliseconds;
+        return true;
+    }
+
+    private static HistorySnapshot ReadLatestCached()
+    {
+        try
+        {
+            if (!File.Exists(DatabasePath))
+            {
+                return null;
+            }
+
+            string walPath = DatabasePath + "-wal";
+            long databaseStamp = File.GetLastWriteTimeUtc(DatabasePath).Ticks;
+            if (File.Exists(walPath))
+            {
+                databaseStamp = Math.Max(databaseStamp, File.GetLastWriteTimeUtc(walPath).Ticks);
+            }
+
+            lock (CacheLock)
+            {
+                if (_cachedSnapshot != null && databaseStamp == _lastDatabaseStamp)
+                {
+                    return _cachedSnapshot;
+                }
+
+                HistorySnapshot latest = ReadLatestFromDatabase();
+                if (latest != null)
+                {
+                    _cachedSnapshot = latest;
+                    _lastDatabaseStamp = databaseStamp;
+                }
+
+                return _cachedSnapshot;
+            }
+        }
+        catch
+        {
+            // 数据库读取只是校准快路径；失败时保持原有无 Progress 行行为。
+            return null;
+        }
+    }
+
+    private static HistorySnapshot ReadLatestFromDatabase()
+    {
+        IntPtr database = IntPtr.Zero;
+        IntPtr statement = IntPtr.Zero;
+
+        try
+        {
+            int openResult = sqlite3_open_v2(
+                ToUtf8Z(DatabasePath),
+                out database,
+                SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX,
+                IntPtr.Zero);
+            if (openResult != SQLITE_OK || database == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            sqlite3_busy_timeout(database, 25);
+
+            const string sql = "SELECT playtime, jsonStr FROM historyTracks ORDER BY playtime DESC LIMIT 1";
+            int prepareResult = sqlite3_prepare_v2(
+                database,
+                ToUtf8Z(sql),
+                -1,
+                out statement,
+                IntPtr.Zero);
+            if (prepareResult != SQLITE_OK || statement == IntPtr.Zero || sqlite3_step(statement) != SQLITE_ROW)
+            {
+                return null;
+            }
+
+            long playtime = sqlite3_column_int64(statement, 0);
+            IntPtr jsonPointer = sqlite3_column_text(statement, 1);
+            string json = jsonPointer == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(jsonPointer);
+            if (playtime <= 0 || string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            JObject track = JObject.Parse(json);
+            string title = track.Value<string>("name");
+            long duration = track.Value<long?>("duration") ?? 0;
+            if (string.IsNullOrWhiteSpace(title) || duration <= 0)
+            {
+                return null;
+            }
+
+            return new HistorySnapshot
+            {
+                Title = title,
+                PlaytimeMilliseconds = playtime,
+                DurationMilliseconds = duration
+            };
+        }
+        finally
+        {
+            if (statement != IntPtr.Zero)
+            {
+                sqlite3_finalize(statement);
+            }
+            if (database != IntPtr.Zero)
+            {
+                sqlite3_close(database);
+            }
+        }
+    }
+
+    private static byte[] ToUtf8Z(string value)
+    {
+        return Encoding.UTF8.GetBytes(value + "\0");
+    }
+
+    private sealed class HistorySnapshot
+    {
+        public string Title { get; set; }
+        public long PlaytimeMilliseconds { get; set; }
+        public long DurationMilliseconds { get; set; }
+    }
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_open_v2(byte[] filename, out IntPtr database, int flags, IntPtr vfs);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_busy_timeout(IntPtr database, int milliseconds);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_prepare_v2(
+        IntPtr database,
+        byte[] sql,
+        int byteCount,
+        out IntPtr statement,
+        IntPtr tail);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_step(IntPtr statement);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern long sqlite3_column_int64(IntPtr statement, int column);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr sqlite3_column_text(IntPtr statement, int column);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_finalize(IntPtr statement);
+
+    [DllImport("winsqlite3.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sqlite3_close(IntPtr database);
+}
+

--- a/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
+++ b/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
@@ -11,6 +11,8 @@ public class NeteaseMusicService : MusicService
     // 用于"音量为 0 时通过进度变化判断播放/暂停"的兜底
     private int _lastProgressSeconds = -1;
     private DateTime _lastProgressChangeTime = DateTime.MinValue;
+    private long _seedPlaytimeMilliseconds = -1;
+    private DateTime _seedProgressUntil = DateTime.MinValue;
 
     public override string GetMusicStatus(AudioSessionManager2 sessionManager)
     {
@@ -107,16 +109,10 @@ public class NeteaseMusicService : MusicService
 
         windowTitle = FixTitleNetease(windowTitle);
 
-        // 通过 UI Automation 读取进度（失败时保持 -1，不输出 Progress 行）
+        // 本机测试的网易云 3.1.38 未暴露可用的 UI Automation 文本树。
+        // 原实现会在这里同步扫描整棵 UIA 树，切歌快通道因而可能被阻塞数秒。
         int currentSec = -1;
         int totalSec = -1;
-        try
-        {
-            NeteaseMusicHelper.ReadProgressViaUIA(out currentSec, out totalSec);
-        }
-        catch (Exception)
-        {
-        }
 
         // 判断播放状态：
         // 优先用音量（反映是否真的在出声）；若音量为 0 但进度最近有变化，则仍视为 Playing
@@ -130,6 +126,29 @@ public class NeteaseMusicService : MusicService
         else
         {
             status = IsProgressChangingRecently(currentSec) ? "Playing" : "Paused";
+        }
+
+        // 改为读取网易云自身 historyTracks 的开播时间。新开播后的前 3 秒会
+        // 重复校准，消除 Java 端处理 Track/歌词事件造成的首个 Progress 排队延迟；
+        // 之后仍由 Now Playing 原有计时器负责推进与暂停。
+        if ("Playing".Equals(status)
+            && NeteaseHistoryReader.TryGetInitialProgress(
+                windowTitle,
+                out int seededCurrentSec,
+                out int seededTotalSec,
+                out long playtimeMilliseconds))
+        {
+            if (playtimeMilliseconds != _seedPlaytimeMilliseconds)
+            {
+                _seedPlaytimeMilliseconds = playtimeMilliseconds;
+                _seedProgressUntil = DateTime.Now.AddSeconds(3);
+            }
+
+            if (DateTime.Now <= _seedProgressUntil)
+            {
+                currentSec = seededCurrentSec;
+                totalSec = seededTotalSec;
+            }
         }
 
         // 输出结果
@@ -206,3 +225,4 @@ public class NeteaseMusicService : MusicService
         return (DateTime.Now - _lastProgressChangeTime).TotalMilliseconds <= 1500;
     }
 }
+


### PR DESCRIPTION
## 问题

在本机的 **Now Playing 2.1.5 + 网易云音乐 3.1.38.205386** 环境中，
网易云窗口不再通过 UI Automation 暴露可匹配的 `MM:SS / MM:SS` Text 元素。

当前 `NeteaseMusicService.GetMusicStatus()` 会在每轮检测中同步执行
`NeteaseMusicHelper.ReadProgressViaUIA()`；全树扫描出现长尾时，歌曲标题和
切歌事件也要等待 UIA 返回。现场样本中，正常切歌识别晚到约
`0.944～4.460s`，Now Playing 中途启动时曾产生约 `53s` 的固定歌词误差。

歌词请求本身并不是主要瓶颈：识别到歌曲后，本机获取歌词通常约
`150～380ms`。

## 本 PR 的 POC 实现

- 不再让当前失效的 UIA 全树扫描阻塞网易云切歌快通道。
- 新增 `NeteaseHistoryReader`，通过 Windows 自带 `winsqlite3.dll` 以只读方式
  查询网易云本地 `webdb.dat` 中最新 `historyTracks.playtime/jsonStr`。
- 只有数据库歌曲标题与当前网易云窗口标题匹配时才使用该记录。
- 仅在检测到新的 `playtime` 后的前 3 秒发送初始 `Progress` 校准；之后继续
  使用 Now Playing 原有计时器。
- 数据库缺失、繁忙、结构变化或解析失败时静默回退，不写入网易云数据库。

## 本机结果

- `/api/query` 识别新曲：约 `449ms`
- 新歌词完成：总计约 `0.83s`
- 中途启动/初始进度差：约 `0.18～1.06s`
- 当前 `master` 上 `dotnet build -c Release`：`0 errors`

## 已知限制

这是 **单台机器、单一版本组合上的 POC**，不是完整的权威时间轴：

- `webdb.dat/historyTracks/playtime/jsonStr` 是网易云私有结构和未公开语义，
  未来客户端更新可能变化。
- `playtime` 在这里仅根据现场行为推断为接近开播时间；暂停、恢复、seek、
  静音、缓冲、睡眠/唤醒和系统校时仍需更多测试。
- 当前只通过窗口标题包含歌曲标题进行匹配；同名歌曲、Live/Remix、本地歌曲、
  播客、私人 FM 等场景尚未覆盖。
- 跳过 UIA 后，音量为零时原有的“进度仍在变化”兜底不再有权威进度输入。
- 读取播放历史涉及隐私；正式版本若采用类似 fallback，建议提供明确说明、
  开关、版本/结构探测和节流日志，并始终只读。

如果维护者不希望采用数据库 fallback，仍建议将 UIA 读取移到后台线程或独立
helper process，增加缓存、时间预算、失败退避/熔断，确保它永远不会阻塞切歌
标题输出；也可以让现有 `smtc` 设置真正对网易云分支生效后再逐级回退。

## 修改文件

- 新增 `Helpers/NeteaseHistoryReader.cs`
- 修改 `MusicServices/NeteaseMusicService.cs`

## 验证

- `git apply --check`
- `git diff --check`
- 敏感信息扫描通过
- `.NET 8 / current master` 构建：`0 errors`（仓库原有警告仍存在）
- 本机启动、切歌、歌词获取与 `/api/query` 对照测试

Refs #53

本次诊断与初始 POC 由 **OpenAI Codex AI Agent** 协助完成。提交者本人不懂
编程；请维护者独立审查、修改并补充跨版本/状态机测试。