### PR TITLE
修复在打开歌词的情况下启动网易云会导致有概率无法追踪进度条更改的问题

### DIFF
--- a/external_programs/AudioService/GetMusicStatus/Helpers/NeteaseMusicHelper.cs
+++ b/external_programs/AudioService/GetMusicStatus/Helpers/NeteaseMusicHelper.cs
@@ -37,6 +37,10 @@ public static class NeteaseMusicHelper
     private static int _currentSec = -1;
     private static int _totalSec = -1;
 
+    // 播放器主窗口句柄（主线程每轮轮询更新）。用于 ElementFromHandle 精确定位主窗口，
+    // 进度条一定在主窗口里，从而避免桌面歌词等其它 cloudmusic 窗口被误选、导致读不到进度。
+    private static IntPtr _playerWindowHandle = IntPtr.Zero;
+
     /// <summary>
     /// 主线程调用：通知 worker 当前曲目已切换（或播放已结束，track 传 null）。
     /// 这里只更新共享状态并唤醒 worker，不做任何 UIA 操作，因此对主线程而言是零成本的。
@@ -62,6 +66,24 @@ public static class NeteaseMusicHelper
             {
                 EnsureWorkerStarted();
             }
+        }
+
+        WorkSignal.Set();
+    }
+
+    /// <summary>
+    /// 主线程调用：更新播放器主窗口句柄（由音频会话的 MainWindowHandle 得到）。
+    /// 句柄变化时唤醒 worker，让其在下一轮通过 ElementFromHandle 重新定位主窗口。
+    /// </summary>
+    public static void SetWindowHandle(IntPtr hwnd)
+    {
+        lock (StateLock)
+        {
+            if (_playerWindowHandle == hwnd)
+            {
+                return;
+            }
+            _playerWindowHandle = hwnd;
         }
 
         WorkSignal.Set();
@@ -159,20 +181,56 @@ public static class NeteaseMusicHelper
                     continue;
                 }
 
-                if (!IsUsablePlayerWindow(cachedWindow))
+                // 本轮要扫描的窗口：优先用主窗口句柄精确定位（ElementFromHandle）。
+                // 进度条一定在主窗口里，用它可避免桌面歌词等其它 cloudmusic 窗口被误选。
+                IUIAutomationElement scanWindow = null;
+                bool scanWindowIsTemp = false;
+
+                IntPtr hwnd;
+                lock (StateLock)
                 {
-                    ReleaseComObject(cachedWindow);
-                    cachedWindow = FindNeteasePlayerWindow(automation);
+                    hwnd = _playerWindowHandle;
+                }
+
+                if (hwnd != IntPtr.Zero)
+                {
+                    try
+                    {
+                        scanWindow = automation.ElementFromHandle(hwnd);
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                if (scanWindow == null)
+                {
+                    // 回退：无可用句柄时，沿用缓存窗口 + PID 枚举
+                    if (!IsUsablePlayerWindow(cachedWindow))
+                    {
+                        ReleaseComObject(cachedWindow);
+                        cachedWindow = FindNeteasePlayerWindow(automation);
+                    }
+                    scanWindow = cachedWindow;
+                }
+                else
+                {
+                    scanWindowIsTemp = true;
                 }
 
                 int currentSec = -1;
                 int totalSec = -1;
 
-                if (cachedWindow != null)
+                if (scanWindow != null)
                 {
                     IUIAutomationElement progressElement =
-                        FindProgressElement(automation, cachedWindow, out currentSec, out totalSec);
+                        FindProgressElement(automation, scanWindow, out currentSec, out totalSec);
                     ReleaseComObject(progressElement);
+                }
+
+                if (scanWindowIsTemp)
+                {
+                    ReleaseComObject(scanWindow);
                 }
 
                 // 无论本轮是否找到进度文本都发布结果：找不到（如用户未 hover 进度条）就发布 -1/-1，

--- a/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
+++ b/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
@@ -18,6 +18,7 @@ public class NeteaseMusicService : MusicService
         double volume = 0;
         bool musicAppRunning = false;
         string windowTitle = "";
+        IntPtr mainWindowHandle = IntPtr.Zero;
 
         AudioSessionEnumerator sessionEnumerator = null;
 
@@ -48,7 +49,13 @@ public class NeteaseMusicService : MusicService
                     musicAppRunning = true;
                     meter = session.QueryInterface<AudioMeterInformation>();
                     volume += meter.PeakValue;
-                    windowTitle = WindowDetector.GetWindowTitleByHandle(sessionControl.Process.MainWindowHandle);
+                    IntPtr hwnd = sessionControl.Process.MainWindowHandle;
+                    windowTitle = WindowDetector.GetWindowTitleByHandle(hwnd);
+                    if (hwnd != IntPtr.Zero)
+                    {
+                        // 记录主窗口句柄（进度条所在窗口），供 UIA 精确定位
+                        mainWindowHandle = hwnd;
+                    }
                 }
 
                 // 释放对象
@@ -107,6 +114,10 @@ public class NeteaseMusicService : MusicService
         }
 
         windowTitle = FixTitleNetease(windowTitle);
+
+        // 每次轮询都把最新的主窗口句柄同步给 UIA worker，
+        // 用于 ElementFromHandle 精确定位主窗口，避免桌面歌词等其它窗口被误选。
+        NeteaseMusicHelper.SetWindowHandle(mainWindowHandle);
 
         // 通过 UI Automation 读取进度（失败时保持 -1，不输出 Progress 行）
         // 切歌首轮只上报标题，不触发 UIA。进度 UIA 在独立 worker 中延后一轮执行；

--- a/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
+++ b/external_programs/AudioService/GetMusicStatus/MusicServices/NeteaseMusicService.cs
@@ -113,6 +113,15 @@ public class NeteaseMusicService : MusicService
             return ApplyHoldover("None");
         }
 
+        // 用 Win32 标题"歌名 - 歌手"定位真正的主窗口（网易云会把主窗口标题改成歌曲名），
+        // 并屏蔽桌面歌词窗口/迷你播放器/SMTC 窗口。MainWindowHandle 在开启桌面歌词时会错指到
+        // "桌面歌词"窗口，因此这里统一重新定位，确保 UIA 读的是主窗口的进度条。
+        IntPtr playerHwnd = WindowDetector.GetPlayerWindowHandle("cloudmusic");
+        if (playerHwnd != IntPtr.Zero)
+        {
+            mainWindowHandle = playerHwnd;
+        }
+
         windowTitle = FixTitleNetease(windowTitle);
 
         // 每次轮询都把最新的主窗口句柄同步给 UIA worker，

--- a/external_programs/AudioService/GetMusicStatus/WindowDetector.cs
+++ b/external_programs/AudioService/GetMusicStatus/WindowDetector.cs
@@ -105,4 +105,43 @@ public class WindowDetector
 
         return windowTitles;
     }
+
+    /// <summary>
+    /// 获取网易云主窗口句柄：枚举所有 cloudmusic 进程的可见顶层窗口，
+    /// 返回标题形如"歌名 - 歌手"（网易云会把主窗口标题改成歌曲名）的窗口句柄。
+    /// 显式屏蔽：桌面歌词窗口（标题含"歌词"）、迷你播放器（标题含"迷你"）、SMTC 窗口（标题含"MediaPlayer"）。
+    /// </summary>
+    public static IntPtr GetPlayerWindowHandle(string processName)
+    {
+        IntPtr result = IntPtr.Zero;
+
+        Process[] processes = Process.GetProcessesByName(processName);
+        if (processes.Length == 0) return IntPtr.Zero;
+
+        HashSet<uint> pids = new HashSet<uint>();
+        foreach (Process p in processes)
+        {
+            pids.Add((uint)p.Id);
+            p.Dispose();
+        }
+
+        EnumWindows(new EnumWindowsProc((hWnd, lParam) =>
+        {
+            GetWindowThreadProcessId(hWnd, out uint pid);
+            if (!pids.Contains(pid)) return true;
+            if (!IsWindowVisible(hWnd)) return true;
+
+            string title = GetWindowTitleByHandle(hWnd);
+            if (string.IsNullOrEmpty(title)) return true;
+            if (title.Contains("MediaPlayer")) return true;   // SMTC 窗口
+            if (title.Contains("歌词")) return true;          // 桌面歌词窗口
+            if (title.Contains("迷你")) return true;          // 迷你播放器
+            if (!title.Contains(" - ")) return true;          // 主窗口标题形如"歌名 - 歌手"
+
+            result = hWnd;
+            return false;  // 已找到主窗口，停止枚举
+        }), IntPtr.Zero);
+
+        return result;
+    }
 }


### PR DESCRIPTION
GetMusicStatus 在网易云模式下运行时会优先挑中标题含 ' - ' 的窗口，而网易云开启桌面歌词功能会在下次启动时保留状态，重启时歌词窗口有概率被先行命中。
而歌词窗口没有进度条，导致读不到主窗口的进度条，因此修改了 NeteaseMusicService 和 ProgressWorker使得程序优先匹配主窗口。

修改如下：
1. 让 NeteaseMusicService 每次轮询从音频会话捕获主窗口句柄 MainWindowHandle，通过新增的 NeteaseMusicHelper.SetWindowHandle 同步给 UIA worker 
2. 并且让 ProgressWorke 优先用 ElementFromHandle句柄锁定主窗口，句柄不可用时才回退到原有的按 PID 枚举